### PR TITLE
✨ feat: Implement JwtGuard and access token reissue endpoint

### DIFF
--- a/src/modules/auth/account.repository.ts
+++ b/src/modules/auth/account.repository.ts
@@ -11,6 +11,10 @@ export class AccountRepository extends Repository<Account> {
     super(Account, dataSource.createEntityManager());
   }
 
+  async findAccountByUid(uid: string): Promise<Account | undefined> {
+    return this.findOne({ where: { uid }})
+  }
+
   async findAccountByEmail(email: string): Promise<Account | undefined> {
     return this.findOne({ where: { email }})
   }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import { SwaggerDecorator                                } from 'src/common/deco
 import { ResultFormatInterceptor                         } from 'src/common/interceptor/result-format.interceptor';
 import { AuthService                                     } from './auth.service';
 import { SignInInputDto, SignInOutputDto, SignUpInputDto } from './dto/auth.dto';
+import { RefreshTokenInputDto, RefreshTokenOutputDto } from './dto/refresh-token.dto';
 
 @ApiTags('AUTH')
 @Controller('auth')
@@ -22,11 +23,11 @@ export class AuthController {
     outputType  : SignInOutputDto,
     requireAuth : false,
   })
-  @Post('/local/signup')
+  @Post('local/signup')
   async signUp(
     @Body() body: SignUpInputDto
   ): Promise<SignInOutputDto> {
-    this.logger.log(`[signUp] info: ${JSON.stringify(body)}`)
+    this.logger.log(`[signUp] info: ${JSON.stringify({ ...body, password: '***' })}`);
 
     return this.authService.signUp(body)
   }
@@ -37,12 +38,25 @@ export class AuthController {
     outputType  : SignInOutputDto,
     requireAuth : false
   })
-  @Post('/local/signin')
+  @Post('local/signin')
   async signIn(
     @Body() body: SignInInputDto
   ): Promise<SignInOutputDto> {
-    this.logger.log(`[signIn] email: ${body.email}`)
+    this.logger.log(`[signIn] info: ${JSON.stringify({ ...body, password: '***' })}`);
     
     return this.authService.signIn(body);
+  }
+
+  @SwaggerDecorator({
+    summary     : '액세스 토큰 재발급',
+    description : '액세스 토큰이 만료된 경우 리프레시 토큰을 통하여 재발급을 받습니다.',
+    outputType  : RefreshTokenOutputDto,
+    requireAuth : false
+  })
+  @Post('refresh')
+  async refreshAccessToken(
+    @Body() body: RefreshTokenInputDto
+  ): Promise<RefreshTokenOutputDto> {
+    return this.authService.refreshAccessToken(body);
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -12,11 +12,12 @@ import { JwtService    } from '@nestjs/jwt';
 import { DataSource    } from 'typeorm';
 
 import { CommonService                                   } from 'src/common/common.service';
-import { Provider                                        } from './enum/account.enum';
+import { TokenInfoConfig                                 } from 'src/config/config';
 import { SignInInputDto, SignInOutputDto, SignUpInputDto } from './dto/auth.dto';
+import { RefreshTokenInputDto, RefreshTokenOutputDto     } from './dto/refresh-token.dto';
 import { AccountRepository                               } from './account.repository';
 import { UserRepository                                  } from '../user/user.repository';
-import { TokenInfoConfig                                 } from 'src/config/config';
+import { Provider                                        } from './enum/account.enum';
 import { AUTH_ERROR, AuthError                           } from './error/auth.error';
 
 @Injectable()
@@ -97,19 +98,51 @@ export class AuthService {
 
       const userAccount = await this.accountRepository.findAccountByEmail(email);
 
-      if(!userAccount) throw new NotFoundException(AUTH_ERROR.ACCOUNT_NOT_FOUND);
+      if(!userAccount) throw new UnauthorizedException(AUTH_ERROR.ACCOUNT_NOT_FOUND);
 
       const isPasswordMatched = await this.commonService.hashCompare(password, userAccount.password);
 
       if(!isPasswordMatched) throw new UnauthorizedException(AUTH_ERROR.ACCOUNT_PASSWORD_WAS_WRONG);
 
-      const { accessToken, refreshToken } = await this.getTokens({ id: userAccount.uid });
+      const { accessToken, refreshToken } = await this.getTokens({ accountUid: userAccount.uid });
 
       await this.accountRepository.updateRefreshToken(userAccount.id, refreshToken);
 
       await queryRunner.commitTransaction();
 
       return { accessToken, refreshToken };
+    } catch(error) {
+      this.logger.error(error);
+
+      await queryRunner.rollbackTransaction();
+
+      const statusCode = error.status || HttpStatus.INTERNAL_SERVER_ERROR;
+      
+      throw new HttpException(this.authError.errorHandler(error.message), statusCode);
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async refreshAccessToken(body: RefreshTokenInputDto): Promise<RefreshTokenOutputDto> {
+    if(!body.refreshToken) throw new UnauthorizedException(AUTH_ERROR.REFRESH_TOKEN_MISSING);
+
+    const queryRunner = this.dataSource.createQueryRunner();
+
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const secret  = this.refreshTokenSecretKey;
+      const decoded = this.jwtService.verify(body.refreshToken, { secret })
+
+      if(!decoded) throw new UnauthorizedException(AUTH_ERROR.REFRESH_TOKEN_VERIFICATION_FAILED);
+
+      const account     = await this.accountRepository.findAccountByUid(decoded.accountUid)
+      const payload     = { accountUid : account.uid };
+      const accessToken = await this.createAccessToken(payload)
+
+      return { accessToken }
     } catch(error) {
       this.logger.error(error);
 

--- a/src/modules/auth/dto/auth.dto.ts
+++ b/src/modules/auth/dto/auth.dto.ts
@@ -79,3 +79,4 @@ export class SignInOutputDto {
   @ApiProperty({ description: '리프레쉬 토큰' })
   refreshToken?: string;
 }
+

--- a/src/modules/auth/dto/refresh-token.dto.ts
+++ b/src/modules/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty, PickType } from "@nestjs/swagger";
+import { IsString              } from "class-validator";
+
+import { SignInOutputDto } from "./auth.dto";
+
+export class RefreshTokenInputDto {
+  @IsString()
+  @ApiProperty({ description: '리프레쉬 토큰', required: true })
+  refreshToken: string;
+}
+
+export class RefreshTokenOutputDto extends PickType(SignInOutputDto, [
+  'accessToken'
+]) { }

--- a/src/modules/auth/error/auth.error.ts
+++ b/src/modules/auth/error/auth.error.ts
@@ -1,14 +1,19 @@
 import { CoreError } from "src/common/error/core.error";
 
 export const AUTH_ERROR = {
-  ACCOUNT_EMAIL_ALREADY_EXIST    : 'emailAlreadyExist',
-  ACCOUNT_NICKNAME_ALREADY_EXIST : 'nicknameAlreadyExist',
-  ACCOUNT_NOT_FOUND              : 'accountNotFound',
-  ACCOUNT_PASSWORD_WAS_WRONG     : 'passwordWasWrong',
-  ACCOUNT_PHONE_ALREADY_EXIST    : 'phoneAlreadyExist',
-  ACCESS_TOKEN_ERROR             : 'accessTokenError',
-  REFRESH_TOKEN_EXPIRED          : 'refreshTokenExpired',
-  REFRESH_TOKEN_NOT_FOUND        : 'refreshTokenNotFound'
+  ACCOUNT_EMAIL_ALREADY_EXIST       : 'emailAlreadyExist',
+  ACCOUNT_NICKNAME_ALREADY_EXIST    : 'nicknameAlreadyExist',
+  ACCOUNT_NOT_FOUND                 : 'accountNotFound',
+  ACCOUNT_PASSWORD_WAS_WRONG        : 'passwordWasWrong',
+  ACCOUNT_PHONE_ALREADY_EXIST       : 'phoneAlreadyExist',
+  ACCESS_TOKEN_MISSING              : 'accessTokenMissing',
+  ACCESS_TOKEN_MALFORMED            : 'accessTokenMalformed',
+  ACCESS_TOKEN_EXPIRED              : 'accessTokenExpired',
+  ACCESS_TOKEN_VERIFICATION_FAILED  : 'accessTokenVerificationFailed',
+  REFRESH_TOKEN_MISSING             : 'refreshTokenMissing',
+  REFRESH_TOKEN_MALFORMED           : 'refreshTokenMalformed',
+  REFRESH_TOKEN_EXPIRED             : 'refreshTokenExpired',
+  REFRESH_TOKEN_VERIFICATION_FAILED : 'refreshTokenVerificationFailed'
 }
 
 export class AuthError extends CoreError {
@@ -36,18 +41,38 @@ export class AuthError extends CoreError {
         id      : AUTH_ERROR.ACCOUNT_PHONE_ALREADY_EXIST,
         message : '이미 가입된 핸드폰 번호입니다.'
       },
-      [AUTH_ERROR.ACCESS_TOKEN_ERROR]: {
-        id      : AUTH_ERROR.ACCESS_TOKEN_ERROR,
-        message : '접근 권한이 없습니다.'
+      [AUTH_ERROR.ACCESS_TOKEN_MISSING]: {
+        id      : AUTH_ERROR.ACCESS_TOKEN_MISSING,
+        message : '엑세스 토큰이 전송되지 않았습니다.'
+      },
+      [AUTH_ERROR.ACCESS_TOKEN_MALFORMED]: {
+        id      : AUTH_ERROR.ACCESS_TOKEN_MALFORMED,
+        message : '엑세스 토큰의 형식이 잘못되었습니다.'
+      },
+      [AUTH_ERROR.ACCESS_TOKEN_EXPIRED]: {
+        id      : AUTH_ERROR.ACCESS_TOKEN_EXPIRED,
+        message : '엑세스 토큰이 만료되었습니다.'
+      },
+      [AUTH_ERROR.ACCESS_TOKEN_VERIFICATION_FAILED]: {
+        id      : AUTH_ERROR.ACCESS_TOKEN_VERIFICATION_FAILED,
+        message : '엑세스 토큰 검증에 실패하였습니다.'
+      },
+      [AUTH_ERROR.REFRESH_TOKEN_MISSING]: {
+        id      : AUTH_ERROR.REFRESH_TOKEN_MISSING,
+        message : '리프레쉬 토큰이 전송되지 않았습니다.'
+      },
+      [AUTH_ERROR.REFRESH_TOKEN_MALFORMED]: {
+        id      : AUTH_ERROR.REFRESH_TOKEN_EXPIRED,
+        message : '리프레쉬 토큰의 형식이 잘못되었습니다.'
       },
       [AUTH_ERROR.REFRESH_TOKEN_EXPIRED]: {
         id      : AUTH_ERROR.REFRESH_TOKEN_EXPIRED,
         message : '리프레쉬 토큰이 만료되었습니다.'
       },
-      [AUTH_ERROR.REFRESH_TOKEN_NOT_FOUND]: {
-        id      : AUTH_ERROR.REFRESH_TOKEN_NOT_FOUND,
-        message : '리프레쉬 토큰이 존재하지 않습니다.'
-      }
+      [AUTH_ERROR.REFRESH_TOKEN_VERIFICATION_FAILED]: {
+        id      : AUTH_ERROR.REFRESH_TOKEN_VERIFICATION_FAILED,
+        message : '리프레쉬 토큰 검증에 실패하였습니다.'
+      },
     }
   }
 }

--- a/src/modules/auth/guard/jwt.guard.ts
+++ b/src/modules/auth/guard/jwt.guard.ts
@@ -1,0 +1,62 @@
+import { 
+  ExecutionContext, 
+  Injectable, 
+  Logger, 
+  UnauthorizedException 
+} from "@nestjs/common";
+import { AuthGuard     } from "@nestjs/passport";
+import { JwtService    } from "@nestjs/jwt"; 
+import { ConfigService } from "@nestjs/config";
+
+import { AccountRepository } from "../account.repository";
+import { AUTH_ERROR        } from "../error/auth.error";
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  private readonly logger = new Logger(JwtAuthGuard.name);
+
+  constructor(
+    private readonly accountRepository : AccountRepository,
+    private readonly jwtService        : JwtService,
+    private readonly configService     : ConfigService
+  ) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request           = context.switchToHttp().getRequest();
+    const { authorization } = request.headers;
+    
+    if(!authorization) throw new UnauthorizedException(AUTH_ERROR.ACCESS_TOKEN_MISSING);
+    
+    const [bearer, token] = authorization.split(' ');
+    
+    if(bearer !== 'Bearer' || !token) throw new UnauthorizedException();
+    
+    const accountUid = await this.validateToken(token);
+    
+    const account    = await this.accountRepository.findAccountByUid(accountUid);
+    
+    if(!account) throw new UnauthorizedException(AUTH_ERROR.ACCOUNT_NOT_FOUND);
+    
+    request.user = {
+      id        : account.user.id,
+      accountId : account.id
+    }
+    
+    return true;
+  }
+
+  private async validateToken(token: string): Promise<string> {
+    try {
+      const secret = this.configService.get<string>('ACCESS_TOKEN_SECRET_KEY');
+      const result = this.jwtService.verify(token, { secret })
+
+      return result.accountUid;
+    } catch(error) {
+      this.logger.error(`Token validation failed: ${error.message}`, error.stack);
+
+      throw new UnauthorizedException(AUTH_ERROR.ACCESS_TOKEN_VERIFICATION_FAILED);
+    }
+  }
+}


### PR DESCRIPTION
## 작업 배경

- JwtGuard 및 AccessToken 재발급 기능을 추가합니다.

</br>

## 작업 내용

- 인가 과정 처리를 위한 JwtGuard를 구현합니다.
- 엑세스토큰의 만료시 리프레쉬 토큰을 통해 재발급 받을 수 있는 엔드포인트를 작성합니다.
- 토큰 프로세스와 연관있는 에러의 종류를 세분화하고 그에 맞게 `AuthError` 클래스를 수정합니다.

</br>